### PR TITLE
fixed link highlight in topbar

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -606,21 +606,23 @@ if (typeof(document.getElementsByClassName("subinfo")[0]) != 'undefined' && docu
 
 /* load all comments on a post */
 if (typeof(document.getElementById("cmnts")) != 'undefined' && document.getElementById("cmnts") != null){
-  document.getElementById("cmnts").children[0].addEventListener('click', function(event){   
-    event.preventDefault();
-    var self = this;
-    var interval = setInterval(function(){
-        var comments = document.getElementsByClassName("loadsibling");
-        if(comments.length == 0){
-            clearInterval(interval);
-            interval = false;
-        }
-        for(var i = 0;i<comments.length;i++){
-            comments[i].click();
-        }
-    },300); 
-    return false;    
-  });
+  if (typeof(document.getElementById("cmnts").children[0]) != 'undefined' && document.getElementById("cmnts").children[0] != null){
+      document.getElementById("cmnts").children[0].addEventListener('click', function(event){   
+        event.preventDefault();
+        var self = this;
+        var interval = setInterval(function(){
+            var comments = document.getElementsByClassName("loadsibling");
+            if(comments.length == 0){
+                clearInterval(interval);
+                interval = false;
+            }
+            for(var i = 0;i<comments.length;i++){
+                comments[i].click();
+            }
+        },300); 
+        return false;    
+      });
+  }
 }  
 
 //topbar active page link indication


### PR DESCRIPTION
when comment exist script works fine, but when there is no comment script was not working because js for show more comments couldn't find the child of element and throw an error, that error broke code and stop the rest of the code from executing, in this case, code below was a function for highlight topbar that couldn't work because of the previous function error.